### PR TITLE
Don't pass non-array-or-object roots to JSON.generate()

### DIFF
--- a/spec/signed_json_spec.rb
+++ b/spec/signed_json_spec.rb
@@ -38,6 +38,44 @@ describe SignedJson do
       expect(JSON.parse(encoded)).to be_instance_of(Array)
     end
 
+    describe "known-good signature from v2.0.0" do
+      {
+        {"hello" => "world"} => "c9bd3c44a91cfe176f71afcc1e08240555f0ce8b",
+        ["hello", "world"] => "67a288435a9268645d399e5969de777096028b2d",
+        nil => "546b281dfcf7e69a4dbcb6a5001929585d65c7d7",
+        "hello world" => "1ed96f0a1cadcee5bd139eb850d39ac1bcda6747",
+        1234 => "307c560360fbf15ecab5a78299052fe68a302d7a",
+      }.each do |data, expected|
+        it "is #{expected} for #{data.inspect}" do
+          encoded = SignedJson::Signer.new("secret").encode(data)
+          signature, payload = JSON.parse(encoded)
+          expect(signature).to eq(expected)
+          expect(payload).to eq(data)
+        end
+      end
+    end
+
+    it "returns known-good signature and payload for object" do
+      encoded = SignedJson::Signer.new("secret").encode(hello: "world")
+      signature, payload = JSON.parse(encoded)
+      expect(signature).to eq("c9bd3c44a91cfe176f71afcc1e08240555f0ce8b")
+      expect(payload).to eq({"hello" => "world"})
+    end
+
+    it "returns known-good signature and payload for array" do
+      encoded = SignedJson::Signer.new("secret").encode(%w(hello world))
+      signature, payload = JSON.parse(encoded)
+      expect(signature).to eq("67a288435a9268645d399e5969de777096028b2d")
+      expect(payload).to eq(["hello", "world"])
+    end
+
+    it "returns known-good signature and payload for nil" do
+      encoded = SignedJson::Signer.new("secret").encode(nil)
+      signature, payload = JSON.parse(encoded)
+      expect(signature).to eq("546b281dfcf7e69a4dbcb6a5001929585d65c7d7")
+      expect(payload).to eq(nil)
+    end
+
   end
 
   describe "Signer#decode error handling" do


### PR DESCRIPTION
If `json_pure` v2.x is loaded, JSON.generate and JSON.dump reject invalid (non-array, non-object) root level objects.  This PR works around this without breaking existing signatures by wrapping invalid root values in an array and then stripping the resulting brackets before input to the HMAC function. It only changes how the HMAC input is generated; it does not change how the final data is encoded.

Previously, without `json_pure`:

```
$ docker run ruby:2.3.1 \
    bash -c "gem install signed_json && ruby -e 'require \"signed_json\"; puts SignedJson::Signer.new(\"secret\").encode(nil)'"
Successfully installed signed_json-2.0.0
1 gem installed
["546b281dfcf7e69a4dbcb6a5001929585d65c7d7",null]
```

Previously, with `json_pure` v2.0.1:

```
$ docker run ruby:2.3.1 \
    bash -c "gem install json_pure signed_json && ruby -r json/pure -r signed_json -e 'puts SignedJson::Signer.new(\"secret\").encode(nil)'"
Successfully installed json_pure-2.0.1
Successfully installed signed_json-2.0.0
2 gems installed
/usr/local/bundle/gems/json_pure-2.0.1/lib/json/common.rb:224:in `generate': only generation of JSON objects or arrays allowed (JSON::GeneratorError)
        from /usr/local/bundle/gems/json_pure-2.0.1/lib/json/common.rb:224:in `generate'
        from /usr/local/bundle/gems/json_pure-2.0.1/lib/json/common.rb:394:in `dump'
        from /usr/local/bundle/gems/signed_json-2.0.0/lib/signed_json.rb:50:in `json_generate'
        from /usr/local/bundle/gems/signed_json-2.0.0/lib/signed_json.rb:29:in `digest_for'
        from /usr/local/bundle/gems/signed_json-2.0.0/lib/signed_json.rb:13:in `encode'
        from -e:1:in `<main>'
```
